### PR TITLE
Wire totalsupply and circsupply into ApiController routing

### DIFF
--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -40,6 +40,12 @@ class ApiController extends AbstractController {
                     case 'masternodes':
                         $data = $this->sapi->masternodes();
                         break;
+                    case 'totalsupply':
+                        $data = $this->sapi->totalsupply();
+                        break;
+                    case 'circsupply':
+                        $data = $this->sapi->circsupply();
+                        break;
                     default:
                         $data = $this->error('Incomplete request. Please check documentation', 2);
                         break;


### PR DESCRIPTION
Exposes GET /api/totalsupply and GET /api/circsupply via the case-2 switch block, delegating to the already-fixed SApi methods.

https://claude.ai/code/session_01VBHtjPSaufbBB5xhDPSpCS