### PR TITLE
Fix asset API endpoints to /api/... and add full routing

### DIFF
--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -46,6 +46,9 @@ class ApiController extends AbstractController {
                     case 'circsupply':
                         $data = $this->sapi->circsupply();
                         break;
+                    case 'assetlist':
+                        $data = $this->sapi->assetlist();
+                        break;
                     default:
                         $data = $this->error('Incomplete request. Please check documentation', 2);
                         break;
@@ -101,6 +104,24 @@ class ApiController extends AbstractController {
                     case 'asset':
                         $data = $this->sapi->asset($request->url_elements[2]);
                         break;
+                    case 'assetstats':
+                        $data = $this->sapi->assetstats($request->url_elements[2]);
+                        break;
+                    case 'assetholders':
+                        $data = $this->sapi->assetholders($request->url_elements[2]);
+                        break;
+                    case 'assetmarket':
+                        $data = $this->sapi->assetmarket($request->url_elements[2]);
+                        break;
+                    case 'assetdividends':
+                        $data = $this->sapi->assetdividends($request->url_elements[2]);
+                        break;
+                    case 'myassets':
+                        $data = $this->sapi->myassets($request->url_elements[2]);
+                        break;
+                    case 'assetlist':
+                        $data = $this->sapi->assetlist(intval($request->url_elements[2]));
+                        break;
                     case 'getblocktransactions':
                         $data = $this->sapi->getblocktransactions($request->url_elements[2]);
                         break;
@@ -110,10 +131,26 @@ class ApiController extends AbstractController {
                 }
                 break;
             case 4:
-                if ($request->url_elements[1] == 'checkaddress') {
-                    $data = $this->sapi->checkaddress($request->url_elements[2], $request->url_elements[3]);
-                } else {
-                    $data = $this->error('Incomplete request. Please check documentation', 2);
+                switch ($request->url_elements[1]) {
+                    case 'checkaddress':
+                        $data = $this->sapi->checkaddress($request->url_elements[2], $request->url_elements[3]);
+                        break;
+                    case 'assetbalance':
+                        // /api/assetbalance/{assetId}/{accountId}
+                        $data = $this->sapi->assetbalance($request->url_elements[2] . ':' . $request->url_elements[3]);
+                        break;
+                    case 'assetmarket':
+                        // /api/assetmarket/{id}/bid  or  /api/assetmarket/{id}/ask
+                        $type = in_array($request->url_elements[3], ['bid', 'ask']) ? $request->url_elements[3] : '';
+                        $data = $this->sapi->assetmarket($request->url_elements[2], $type);
+                        break;
+                    case 'assetlist':
+                        // /api/assetlist/{limit}/{offset}
+                        $data = $this->sapi->assetlist(intval($request->url_elements[2]), intval($request->url_elements[3]));
+                        break;
+                    default:
+                        $data = $this->error('Incomplete request. Please check documentation', 2);
+                        break;
                 }
                 break;
             case 5:

--- a/doc/api_data.js
+++ b/doc/api_data.js
@@ -1538,11 +1538,11 @@ define({ "api": [
   },
   {
     "type": "get",
-    "url": window.location.hostname+"/asset",
-    "title": "01. listAssets",
-    "name": "listAssets",
-    "group": "ASSETS",
-    "description": "<p>Returns a paginated list of all assets created on the chain. The short form <code>/asset</code> or <code>/asset/list</code> returns the first 50 assets ordered by creation height (newest first). Use the <code>/asset/list/{limit}/{offset}</code> form for pagination.</p>",
+    "url": window.location.hostname+"/api/assetlist",
+    "title": "26. assetList",
+    "name": "assetList",
+    "group": "API",
+    "description": "<p>Returns a paginated list of all assets created on the chain. Returns the first 50 assets ordered by creation height (newest first). Use <code>/api/assetlist/{limit}</code> or <code>/api/assetlist/{limit}/{offset}</code> for custom pagination.</p>",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -1565,7 +1565,7 @@ define({ "api": [
       "examples": [
         {
           "title": "Request-Examples:",
-          "content": "GET /asset\nGET /asset/list\nGET /asset/list/10\nGET /asset/list/10/20",
+          "content": "GET /api/assetlist\nGET /api/assetlist/10\nGET /api/assetlist/10/20",
           "type": "text"
         }
       ]
@@ -1647,15 +1647,15 @@ define({ "api": [
       }
     },
     "version": "1.0.1",
-    "filename": "./asset",
-    "groupTitle": "ASSETS"
+    "filename": "./api",
+    "groupTitle": "API"
   },
   {
     "type": "get",
-    "url": window.location.hostname+"/asset/get/$id",
-    "title": "02. getAsset",
+    "url": window.location.hostname+"/api/asset/$id",
+    "title": "27. getAsset",
     "name": "getAsset",
-    "group": "ASSETS",
+    "group": "API",
     "description": "<p>Returns full details for a single asset, including its current circulating supply and holder count. The <code>$id</code> may be the asset address, the issuer's public key, or the account alias.</p>",
     "parameter": {
       "fields": {
@@ -1672,7 +1672,7 @@ define({ "api": [
       "examples": [
         {
           "title": "Request-Example:",
-          "content": "GET /asset/get/3G6Xa...",
+          "content": "GET /api/asset/3G6Xa...",
           "type": "text"
         }
       ]
@@ -1740,15 +1740,15 @@ define({ "api": [
       }
     },
     "version": "1.0.1",
-    "filename": "./asset",
-    "groupTitle": "ASSETS"
+    "filename": "./api",
+    "groupTitle": "API"
   },
   {
     "type": "get",
-    "url": window.location.hostname+"/asset/stats/$id",
-    "title": "03. assetStats",
+    "url": window.location.hostname+"/api/assetstats/$id",
+    "title": "28. assetStats",
     "name": "assetStats",
-    "group": "ASSETS",
+    "group": "API",
     "description": "<p>Returns aggregate statistics for an asset: supply, holder count, open order book depth, last trade price, and total dividend distributions.</p>",
     "parameter": {
       "fields": {
@@ -1847,15 +1847,15 @@ define({ "api": [
       ]
     },
     "version": "1.0.1",
-    "filename": "./asset",
-    "groupTitle": "ASSETS"
+    "filename": "./api",
+    "groupTitle": "API"
   },
   {
     "type": "get",
-    "url": window.location.hostname+"/asset/holders/$id",
-    "title": "04. assetHolders",
+    "url": window.location.hostname+"/api/assetholders/$id",
+    "title": "29. assetHolders",
     "name": "assetHolders",
-    "group": "ASSETS",
+    "group": "API",
     "description": "<p>Returns the list of accounts holding a given asset, ranked by balance (highest first).</p>",
     "parameter": {
       "fields": {
@@ -1905,16 +1905,16 @@ define({ "api": [
       }
     },
     "version": "1.0.1",
-    "filename": "./asset",
-    "groupTitle": "ASSETS"
+    "filename": "./api",
+    "groupTitle": "API"
   },
   {
     "type": "get",
-    "url": window.location.hostname+"/asset/market/$id",
-    "title": "05. assetMarket",
+    "url": window.location.hostname+"/api/assetmarket/$id",
+    "title": "30. assetMarket",
     "name": "assetMarket",
-    "group": "ASSETS",
-    "description": "<p>Returns the open order book for an asset. Append <code>/bid</code> or <code>/ask</code> to filter to buy or sell orders respectively. Without a filter, all open orders are returned.</p>",
+    "group": "API",
+    "description": "<p>Returns the open order book for an asset. Append <code>/bid</code> or <code>/ask</code> to filter to buy or sell orders: <code>/api/assetmarket/{id}/bid</code> or <code>/api/assetmarket/{id}/ask</code>. Without a filter, all open orders are returned.</p>",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -1937,7 +1937,7 @@ define({ "api": [
       "examples": [
         {
           "title": "Request-Examples:",
-          "content": "GET /asset/market/3G6Xa...\nGET /asset/market/3G6Xa.../bid\nGET /asset/market/3G6Xa.../ask",
+          "content": "GET /api/assetmarket/3G6Xa...\nGET /api/assetmarket/3G6Xa.../bid\nGET /api/assetmarket/3G6Xa.../ask",
           "type": "text"
         }
       ]
@@ -2012,15 +2012,15 @@ define({ "api": [
       }
     },
     "version": "1.0.1",
-    "filename": "./asset",
-    "groupTitle": "ASSETS"
+    "filename": "./api",
+    "groupTitle": "API"
   },
   {
     "type": "get",
-    "url": window.location.hostname+"/asset/dividends/$id",
-    "title": "06. assetDividends",
+    "url": window.location.hostname+"/api/assetdividends/$id",
+    "title": "31. assetDividends",
     "name": "assetDividends",
-    "group": "ASSETS",
+    "group": "API",
     "description": "<p>Returns the dividend distribution history for an asset. Includes both manual distributions (transaction version 54) and automated per-block distributions (version 57).</p>",
     "parameter": {
       "fields": {
@@ -2091,16 +2091,16 @@ define({ "api": [
       }
     },
     "version": "1.0.1",
-    "filename": "./asset",
-    "groupTitle": "ASSETS"
+    "filename": "./api",
+    "groupTitle": "API"
   },
   {
     "type": "get",
-    "url": window.location.hostname+"/asset/balance/$assetId/$accountId",
-    "title": "07. assetBalance",
+    "url": window.location.hostname+"/api/assetbalance/$assetId/$accountId",
+    "title": "32. assetBalance",
     "name": "assetBalance",
-    "group": "ASSETS",
-    "description": "<p>Returns the balance of a specific asset for a given account. The asset and account can each be specified as an address, public key, or alias. Two URL forms are supported: slash-separated (<code>/asset/balance/{assetId}/{accountId}</code>) or colon-separated (<code>/asset/balance/{assetId}:{accountId}</code>).</p>",
+    "group": "API",
+    "description": "<p>Returns the balance of a specific asset for a given account. The asset and account can each be specified as an address, public key, or alias. Two URL forms are supported: slash-separated (<code>/api/assetbalance/{assetId}/{accountId}</code>) or colon-separated (<code>/api/assetbalance/{assetId}:{accountId}</code>).</p>",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -2123,7 +2123,7 @@ define({ "api": [
       "examples": [
         {
           "title": "Request-Examples:",
-          "content": "GET /asset/balance/3G6Xa.../5XXSb...\nGET /asset/balance/3G6Xa...:5XXSb...",
+          "content": "GET /api/assetbalance/3G6Xa.../5XXSb...\nGET /api/assetbalance/3G6Xa...:5XXSb...",
           "type": "text"
         }
       ]
@@ -2163,15 +2163,15 @@ define({ "api": [
       ]
     },
     "version": "1.0.1",
-    "filename": "./asset",
-    "groupTitle": "ASSETS"
+    "filename": "./api",
+    "groupTitle": "API"
   },
   {
     "type": "get",
-    "url": window.location.hostname+"/asset/myassets/$account",
-    "title": "08. myAssets",
+    "url": window.location.hostname+"/api/myassets/$account",
+    "title": "33. myAssets",
     "name": "myAssets",
-    "group": "ASSETS",
+    "group": "API",
     "description": "<p>Returns all assets held by a specific account where the balance is greater than zero. The account can be specified as an address, public key, or alias.</p>",
     "parameter": {
       "fields": {
@@ -2242,8 +2242,8 @@ define({ "api": [
       }
     },
     "version": "1.0.1",
-    "filename": "./asset",
-    "groupTitle": "ASSETS"
+    "filename": "./api",
+    "groupTitle": "API"
   },
   {
     "type": "php util.php",

--- a/library/classes/SApi.php
+++ b/library/classes/SApi.php
@@ -622,6 +622,36 @@ class SApi {
         return api_echo(['circulating_supply' => $circulation]);
     }
 
+    public function assetlist($limit = 50, $offset = 0) {
+        $res = $this->sassets->list_assets($limit, $offset);
+        return ($res !== false && $res !== []) ? api_echo($res) : api_err("No assets found");
+    }
+
+    public function assetstats($id) {
+        $res = $this->sassets->get_stats($id);
+        return $res ? api_echo($res) : api_err("Asset not found");
+    }
+
+    public function assetholders($id) {
+        $res = $this->sassets->get_holders($id);
+        return ($res !== false) ? api_echo($res) : api_err("Asset not found");
+    }
+
+    public function assetmarket($id, $type = '') {
+        $res = $this->sassets->get_market_orders($id, $type);
+        return ($res !== false) ? api_echo($res) : api_err("Asset not found");
+    }
+
+    public function assetdividends($id) {
+        $res = $this->sassets->get_dividend_history($id);
+        return ($res !== false) ? api_echo($res) : api_err("Asset not found");
+    }
+
+    public function myassets($account) {
+        $res = $this->sassets->get_account_assets($account);
+        return ($res !== false) ? api_echo($res) : api_err("Account not found");
+    }
+
 }
 
 ?>


### PR DESCRIPTION
- All asset endpoints now live under /api/... consistent with the rest of the API surface (no separate /asset/... URLs in docs)
- Added 6 new SApi wrapper methods: assetlist, assetstats, assetholders, assetmarket, assetdividends, myassets — each delegates to SAssets
- Extended ApiController case 2/3/4 to route the new endpoints
- ApiController case 4 rewritten as a switch to support assetbalance, assetmarket (bid/ask filter), and assetlist with offset
- Doc entries 26-33 added to API group with correct /api/... URLs

https://claude.ai/code/session_01VBHtjPSaufbBB5xhDPSpCS