### PR TITLE
Add propWallet to docs and remove dead duplicate case in ApiController

### DIFF
--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -122,9 +122,6 @@ class ApiController extends AbstractController {
                     case 'assetlist':
                         $data = $this->sapi->assetlist(intval($request->url_elements[2]));
                         break;
-                    case 'getblocktransactions':
-                        $data = $this->sapi->getblocktransactions($request->url_elements[2]);
-                        break;
                     default:
                         $data = $this->error('Incomplete request. Please check documentation', 2);
                         break;

--- a/doc/api_data.js
+++ b/doc/api_data.js
@@ -2246,6 +2246,57 @@ define({ "api": [
     "groupTitle": "API"
   },
   {
+    "type": "get",
+    "url": window.location.hostname+"/api/propwallet/$public_key",
+    "title": "34. propWallet",
+    "name": "propWallet",
+    "group": "API",
+    "description": "<p>Registers a public key with this node, ensuring the associated account address is stored before any transactions arrive. Useful when setting up a new wallet on the network so peers have the account record in advance. Returns a success acknowledgement; the caller should verify the account is present afterwards.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "string",
+            "optional": false,
+            "field": "public_key",
+            "description": "<p>The account's public key (base58-encoded secp256k1 public key)</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Request-Example:",
+          "content": "GET /api/propwallet/PZ8Tyr4Nx8MHsRAGMpZmZ6TWY63dXWSCyjGMdVDanywM3CbqvswVqysqU8XS87FcjpqNijtpRSSQ36WexRDv3rJL5X8qpGvzvznuErSRMfb2G6aNoiaT3aEJ",
+          "type": "text"
+        }
+      ]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Confirmation message: &quot;Storing wallet attempted - check to verify&quot;</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "{\"status\":\"ok\",\"data\":\"Storing wallet attempted - check to verify\"}",
+          "type": "json"
+        }
+      ]
+    },
+    "version": "1.0.1",
+    "filename": "./api",
+    "groupTitle": "API"
+  },
+  {
     "type": "php util.php",
     "url": "balance",
     "title": "Balance",


### PR DESCRIPTION
- Documented GET /api/propwallet/{public_key} as entry 34 in api_data.js (was routed but completely absent from docs)
- Removed unreachable duplicate 'getblocktransactions' case from ApiController case 3 switch (first matching case was already at line 84)

https://claude.ai/code/session_01VBHtjPSaufbBB5xhDPSpCS