### PR TITLE
Fix valid_key() rejecting empty strings for pre-signed transactions

### DIFF
--- a/library/classes/SWallet.php
+++ b/library/classes/SWallet.php
@@ -75,7 +75,7 @@ class SWallet {
 
     // check the validity of a base58 encoded key. At the moment, it checks only the characters to be base58.
     public function valid_key($id) {
-        return (bool) preg_match('/^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$/', $id);
+        return (bool) preg_match('/^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]*$/', $id);
     }
 
     //check alias validity


### PR DESCRIPTION
The original character loop returned true for empty input (zero iterations). Replacing + with * in the regex restores that behaviour — pre-signed transactions pass an empty private_key which must be accepted.