### PR TITLE
Rewrite wallet history query from OR to UNION to eliminate table locks

### DIFF
--- a/library/classes/SWallet.php
+++ b/library/classes/SWallet.php
@@ -199,8 +199,14 @@ class SWallet {
             $limit = 100;
         }
         $res = $db->run(
-                "SELECT * FROM transactions WHERE dst=:dst or public_key=:src or dst=:alias ORDER by height DESC LIMIT :limit",
-                [":src" => $public_key, ":dst" => $id, ":limit" => $limit, ":alias" => $alias]
+                "(SELECT * FROM transactions WHERE dst=:dst ORDER BY height DESC LIMIT :limit)
+                 UNION
+                 (SELECT * FROM transactions WHERE public_key=:src ORDER BY height DESC LIMIT :limit2)
+                 UNION
+                 (SELECT * FROM transactions WHERE dst=:alias ORDER BY height DESC LIMIT :limit3)
+                 ORDER BY height DESC LIMIT :limit4",
+                [":dst" => $id, ":src" => $public_key, ":alias" => $alias,
+                 ":limit" => $limit, ":limit2" => $limit, ":limit3" => $limit, ":limit4" => $limit]
         );
 
         $transactions = [];


### PR DESCRIPTION
The previous query used OR across dst and public_key columns, preventing MySQL from using indexes efficiently and causing full table sorts on the 17M-row transactions table, which locked the database for other queries.

Replaced with a UNION of three separate indexed lookups (by dst, by public_key, by alias), each bounded by the limit before merging. Requires composite indexes (dst, height) and (public_key, height) on transactions.