### PR TITLE
Add rebuild notice to master README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **The next-generation Go/Cosmos SDK core is being built on [`lars/rebuild`](../../tree/lars/rebuild).**  
+> Full architecture spec: [`docs/FUTURE-ARCHITECTURE.md`](../../blob/lars/rebuild/docs/FUTURE-ARCHITECTURE.md)
+
+---
+
 # node
 
 The Steroid4.0 (BPC) masternode testnet.


### PR DESCRIPTION
Adds a two-line notice at the top of the master README pointing visitors to `lars/rebuild` and the architecture spec. Everything below is untouched.