### PR TITLE
fix: gettransactions API returning empty results

### DIFF
--- a/library/classes/SWallet.php
+++ b/library/classes/SWallet.php
@@ -199,11 +199,13 @@ class SWallet {
             $limit = 100;
         }
         $res = $db->run(
-                "(SELECT * FROM transactions WHERE dst=:dst ORDER BY height DESC LIMIT :limit)
+                "SELECT * FROM (
+                 (SELECT * FROM transactions WHERE dst=:dst ORDER BY height DESC LIMIT :limit)
                  UNION
                  (SELECT * FROM transactions WHERE public_key=:src ORDER BY height DESC LIMIT :limit2)
                  UNION
                  (SELECT * FROM transactions WHERE dst=:alias ORDER BY height DESC LIMIT :limit3)
+                 ) t
                  ORDER BY height DESC LIMIT :limit4",
                 [":dst" => $id, ":src" => $public_key, ":alias" => $alias,
                  ":limit" => $limit, ":limit2" => $limit, ":limit3" => $limit, ":limit4" => $limit]

--- a/library/classes/SWallet.php
+++ b/library/classes/SWallet.php
@@ -210,7 +210,7 @@ class SWallet {
         );
 
         $transactions = [];
-        foreach ($res as $x) {
+        foreach (($res ?: []) as $x) {
             if($x['version'] != 57){
             $trans = [
                 "block" => $x['block'],


### PR DESCRIPTION
The `gettransactions` API was returning an empty array for all addresses despite transactions existing in the database.

**Root cause:** The UNION query in `SWallet::get_transactions()` was wrapped in a leading `(` parenthesis. The `db->run()` method uses a regex to detect SELECT queries before calling `fetchAll()`, but the regex matches from the start of the string — so `(SELECT ...` didn't match, `fetchAll` was never called, and `null` was returned silently.

**Fix:** Wrap the UNION in a subquery starting with `SELECT * FROM (...)` so the regex correctly identifies it as a SELECT and returns results.
